### PR TITLE
Minor cleanup in RobotContainer

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -42,19 +42,25 @@ import org.strykeforce.telemetry.TelemetryService;
  */
 public class RobotContainer {
 
-  // The robot's subsystems and commands are defined here...
   private final DriveSubsystem driveSubsystem = new DriveSubsystem();
   private final ShooterSubsystem shooterSubsystem = new ShooterSubsystem();
   private final MagazineSubsystem magazineSubsystem = new MagazineSubsystem();
   private final IntakeSubsystem intakeSubsystem = new IntakeSubsystem();
   private final TurretSubsystem turretSubsystem = new TurretSubsystem();
   private final VisionSubsystem visionSubsystem = new VisionSubsystem();
-  private TelemetryService telemetryService = new TelemetryService(TelemetryController::new);
-  private Joystick driveJoystick = new Joystick(0);
+  private final TelemetryService telemetryService = new TelemetryService(TelemetryController::new);
+
+  private final Joystick driveJoystick = new Joystick(0);
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
+    configureTelemetry();
+    configureDriverButtonBindings();
+    configurePitDashboard();
+    turretSubsystem.zeroTurret();
+  }
 
+  private void configureTelemetry() {
     driveSubsystem.registerWith(telemetryService);
     shooterSubsystem.registerWith(telemetryService);
     magazineSubsystem.registerWith(telemetryService);
@@ -62,10 +68,6 @@ public class RobotContainer {
     intakeSubsystem.registerWith(telemetryService);
     visionSubsystem.registerWith(telemetryService);
     telemetryService.start();
-    // Configure the button bindings
-    configureDriverButtonBindings();
-    configurePitDashboard();
-    turretSubsystem.zeroTurret();
   }
 
   /**
@@ -147,7 +149,7 @@ public class RobotContainer {
     LEFT_DOWN(4),
     LEFT_UP(5);
 
-    private final int id;
+    public final int id;
 
     Shoulder(int id) {
       this.id = id;
@@ -157,7 +159,7 @@ public class RobotContainer {
   public enum Toggle {
     LEFT_TOGGLE(1);
 
-    private final int id;
+    public final int id;
 
     Toggle(int id) {
       this.id = id;
@@ -171,7 +173,7 @@ public class RobotContainer {
     UP(16),
     DOWN(17);
 
-    private final int id;
+    public final int id;
 
     Button(int id) {
       this.id = id;
@@ -188,7 +190,7 @@ public class RobotContainer {
     RIGHT_Y_POS(12),
     RIGHT_Y_NEG(13);
 
-    private final int id;
+    public final int id;
 
     Trim(int id) {
       this.id = id;


### PR DESCRIPTION
- added `final` to `VisionSubsystem` and `TelemetryService`
- extracted `configureTelemetry` to keep all constructor statements at the same "altitude" and get rid of "TelemetryService can be a local variable" warning
- `id` fields in controller enums are meant to be accessable


@mwitcpalek: `turretSubsystem.zeroTurret();` is in the constructor here, see any issue in moving it to the `TurretSubsystem` constructor? It's kind on an internal turret implementation detail