### PR TITLE
Fix logging initialization

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Robot extends TimedRobot {
 
-  private Logger logger = LoggerFactory.getLogger(Robot.class);
+  private Logger logger;
   private RobotContainer m_robotContainer;
   private boolean haveAlliance;
 
@@ -44,6 +44,8 @@ public class Robot extends TimedRobot {
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
+    // first call to LoggerFactory.getLogger must be after RobotContainer sets logging location
+    logger = LoggerFactory.getLogger(Robot.class);
     haveAlliance = false;
 
     CommandScheduler.getInstance()

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -92,7 +92,6 @@ import org.strykeforce.telemetry.TelemetryService;
  * subsystems, commands, and button mappings) should be declared here.
  */
 public class RobotContainer {
-  private boolean isEvent = true;
   private boolean haveZeroedClimb = false;
   private DigitalInput eventFlag = new DigitalInput(DashboardConstants.kLockoutBNCid);
   private DriveSubsystem driveSubsystem;
@@ -117,10 +116,11 @@ public class RobotContainer {
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
-    isEvent = eventFlag.get();
+    boolean isEvent = eventFlag.get();
     if (isEvent) {
-      System.out.println("Event Flag Removed - switching to log file");
+      // must be set before the first call to  LoggerFactory.getLogger();
       System.setProperty(ContextInitializer.CONFIG_FILE_PROPERTY, "logback-event.xml");
+      System.out.println("Event Flag Removed - logging to file in ~lvuser/logs/");
     }
     driveSubsystem = new DriveSubsystem();
     visionSubsystem = new VisionSubsystem();


### PR DESCRIPTION
System property with logging config file must be set before first call to `LoggerFactory.getLogger()` ([docs](https://logback.qos.ch/manual/configuration.html#configFileProperty)).
